### PR TITLE
Variables b:completing... not reset to 0 after second function call

### DIFF
--- a/autoload/haskellcomplete.vim
+++ b/autoload/haskellcomplete.vim
@@ -63,6 +63,7 @@ function! haskellcomplete#Complete(findstart, base)
                     call add(l:matches, extension)
                 endif
             endfor
+            let b:completingLangExtension = 0
             return l:matches
         endif
 
@@ -78,6 +79,7 @@ function! haskellcomplete#Complete(findstart, base)
                     call add(l:matches, flag)
                 endif
             endfor
+            let b:completingOptionsGHC = 0
             return l:matches
         endif
 
@@ -93,6 +95,7 @@ function! haskellcomplete#Complete(findstart, base)
                     call add(l:matches, module)
                 endif
             endfor
+            let b:completingModule = 0
             return l:matches
         endif
 


### PR DESCRIPTION
The buffer variables `b:completingLangExtension`, `b:completingOptionsGHC` and `b:completingModule` are not reset to 0 after the second call of the omnifunc, leading to a full list all possible values for the last kind of completion when invoking omnicompletion at a position that does not match any of the three kinds of completion.
